### PR TITLE
feat: add shield-backups feature to blacksmith env

### DIFF
--- a/templates/env/blacksmith
+++ b/templates/env/blacksmith
@@ -31,14 +31,11 @@ kit:
   - ${OCFP_IAAS}
   - ocfp
   #- bosh-dns-health-check
-  #- broker-tls
-  #- redis-tls
   #- redis-dual-mode
   #- rabbitmq
-  #- rabbitmq-tls
   #- rabbitmq-dual-mode
-  #- rabbitmq-dashboard-registration
   #- postgresql
+  #- shield-backups
 YAML
 
 cat <<-YAML
@@ -57,10 +54,17 @@ esac
 cat <<-YAML
 
 params:
+  dns_cache: true # DNS Caching (for runtime config)
+
 #  ocfp:
 #    env:
 #      scale: "prod" # default is "dev"
-  dns_cache: true # DNS Caching (for runtime config)
+
+#   shield_agent:     "127.0.0.1:5444" # IP:PORT
+#   shield_store:     "..."
+
+#   shield:
+#     deployment_env:   "..."
+#     deployment_type:  "shield"
 
 YAML
-

--- a/templates/env/blacksmith
+++ b/templates/env/blacksmith
@@ -31,6 +31,7 @@ kit:
   - ${OCFP_IAAS}
   - ocfp
   #- bosh-dns-health-check
+  #- redis
   #- redis-dual-mode
   #- rabbitmq
   #- rabbitmq-dual-mode


### PR DESCRIPTION
Removed the following features as they are enabled by default:
```
  #- broker-tls
  #- redis-tls
  #- rabbitmq-tls
  #- rabbitmq-dashboard-registration
```

Added the following params block for the feature `shield-backups`:
```
#   shield_agent:     "127.0.0.1:5444" # IP:PORT
#   shield_store:     "..."

#   shield:
#     deployment_env:   "..."
#     deployment_type:  "shield"
```

**NOTE: the shield-kit should store in Vault the agent address to reduce the manual configuration needed.**