### PR TITLE
Adding support for v2 only metadata endpoints for linux vm types

### DIFF
--- a/templates/configs/cloud/aws/ocf.yml
+++ b/templates/configs/cloud/aws/ocf.yml
@@ -26,322 +26,482 @@ azs:
 vm_types:
 - name: default-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.default.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: default-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.default.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: compilation-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.compilation.dev ))
     ephemeral_disk: { size: 32768,  type: gp3, encrypted: true }
 - name: compilation-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.compilation.prod ))
     ephemeral_disk: { size: 32768,  type: gp3, encrypted: true }
 - name: bosh-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.bosh.dev ))
     ephemeral_disk: { size: 65536,  type: gp3, encrypted: true }
 - name: bosh-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.bosh.prod ))
     ephemeral_disk: { size: 131072, type: gp3, encrypted: true }
 - name: api-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.api.dev ))
     ephemeral_disk: { size: 32768,  type: gp3, encrypted: true }
 - name: api-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.api.prod ))
     ephemeral_disk: { size: 65536,  type: gp3, encrypted: true }
 - name: as-api-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.api.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: as-api-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.as-api.prod ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: as-actors-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.as-actors.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: as-actors-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.as-actors.prod ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: as-metrics-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.as-metrics.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: as-metrics-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.as-metrics.prod ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: as-nozzle-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.as-nozzle.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: as-nozzle-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.as-nozzle.prod ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: app-scheduler-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.app-scheduler.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: app-scheduler-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.app-scheduler.prod ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: bbs-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.bbs.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: bbs-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.bbs.prod ))
     ephemeral_disk: { size: 8192,   type: gp3, encrypted: true }
 - name: blobstore-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blobstore.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blobstore-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blobstore.prod ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: cc-worker-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.cc-worker.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: cc-worker-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.cc-worker.prod ))
     ephemeral_disk: { size: 8192,   type: gp3, encrypted: true }
 - name: credhub-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.credhub.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: credhub-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.credhub.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: diego-cell-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.diego-cell.dev ))
     ephemeral_disk: { size: 65536,  type: gp3, encrypted: true }
 - name: diego-cell-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.diego-cell.prod ))
     ephemeral_disk: { size: 393216, type: gp3, encrypted: true }
 - name: diego-api-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.diego-api.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: diego-api-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.diego-api.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: doppler-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.doppler.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: doppler-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.doppler.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: errand-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.errand.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: errand-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.errand.prod ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: haproxy-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.haproxy.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: haproxy-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.haproxy.prod ))
     ephemeral_disk: { size: 8192,   type: gp3, encrypted: true }
 - name: log-api-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.log-api.dev ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: log-api-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.log-api.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: loggregator-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.loggregator.dev ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: loggregator-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.loggregator.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: nats-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.nats.dev ))
     ephemeral_disk: { size: 8192,   type: gp3, encrypted: true }
 - name: nats-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.nats.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: postgres-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.postgres.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: postgres-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.postgres.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: router-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.router.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: router-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.router.prod ))
     ephemeral_disk: { size: 16384,   type: gp3, encrypted: true }
 - name: scheduler-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.scheduler.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: scheduler-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.scheduler.prod ))
     ephemeral_disk: { size: 8192,   type: gp3, encrypted: true }
 - name: syslogger-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.syslogger.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: syslogger-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.syslogger.prod ))
     ephemeral_disk: { size: 8192,   type: gp3, encrypted: true }
 - name: tcp-router-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.tcp-router.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: tcp-router-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.tcp-router.prod ))
     ephemeral_disk: { size: 16384,   type: gp3, encrypted: true }
 - name: uaa-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.uaa.dev ))
     ephemeral_disk: { size: 4096,   type: gp3, encrypted: true }
 - name: uaa-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.uaa.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: shield-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.shield.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: shield-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.shield.prod ))
     ephemeral_disk: { size: 16384,  type: gp3, encrypted: true }
 - name: blacksmith-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blacksmith-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: blacksmith-redis-small-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-redis-small.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blacksmith-redis-small-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-redis-small.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: blacksmith-redis-medium-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-redis-medium.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blacksmith-redis-medium-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-redis-medium.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: blacksmith-redis-large-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-redis-large.dev ))
     ephemeral_disk: { size: 4096, type: gp3, encrypted: true }
 - name: blacksmith-redis-large-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-redis-large.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: blacksmith-rabbitmq-small-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-rabbitmq-small.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blacksmith-rabbitmq-small-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-rabbitmq-small.prod ))
     ephemeral_disk: { size: 8192,  type: gp3, encrypted: true }
 - name: blacksmith-rabbitmq-medium-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-rabbitmq-medium.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blacksmith-rabbitmq-medium-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-rabbitmq-medium.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: blacksmith-rabbitmq-large-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-rabbitmq-large.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blacksmith-rabbitmq-large-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-rabbitmq-large.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: blacksmith-postgres-small-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-postgres-small.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blacksmith-postgres-small-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-postgres-small.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: blacksmith-postgres-medium-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-postgres-medium.dev ))
     ephemeral_disk: { size: 4096,  type: gp3, encrypted: true }
 - name: blacksmith-postgres-medium-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-postgres-medium.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: blacksmith-postgres-large-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-postgres-large.dev ))
     ephemeral_disk: { size: 4096, type: gp3, encrypted: true }
 - name: blacksmith-postgres-large-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.blacksmith-postgres-large.prod ))
     ephemeral_disk: { size: 8192, type: gp3, encrypted: true }
 - name: concourse-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.concourse.dev ))
     ephemeral_disk: { size: 65536, type: gp3, encrypted: true }
 - name: concourse-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.concourse.prod ))
     ephemeral_disk: { size: 131072, type: gp3, encrypted: true }
 - name: concourse-worker-dev
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.concourse-worker.dev ))
     ephemeral_disk: { size: 65536, type: gp3, encrypted: true }
 - name: concourse-worker-prod
   cloud_properties:
+    metadata_options:
+      http_tokens: required
     instance_type: (( grab meta.vm_types.concourse-worker.prod ))
     ephemeral_disk: { size: 262144, type: gp3, encrypted: true }
 - name: windows-cell-dev


### PR DESCRIPTION
This configuration prevents a vm from returning AWS Metadata v1 information from http://169.254.169.254/latest/meta-data/